### PR TITLE
Python 2 check prior to loading StringIO module

### DIFF
--- a/samples/magic/az_ml_magic.py
+++ b/samples/magic/az_ml_magic.py
@@ -7,8 +7,13 @@ import shlex
 import re
 import platform
 
-from cStringIO import StringIO
 import sys
+PYTHON_2 = sys.version_info < (3,0)
+
+if PYTHON_2:
+    from cStringIO import StringIO
+else:
+    from io import StringIO
 
 
 class Capturing(list):


### PR DESCRIPTION
StringIO was deprecated in Python 3.x, use [io instead](https://docs.python.org/3/whatsnew/3.0.html).